### PR TITLE
feat: add support for excludeClass option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ themeConfig: {
     // Default: 1000
     timeout: 1000,
     
+    // Add this class to any element within the Panzoom element that you want to exclude from Panzoom handling.
+    // That element's children will also be excluded. e.g. links and buttons that should not propagate the click event.
+    // Default: 'panzoom-exclude'
+    excludeClass: 'panzoom-exclude',
+    
     // You can also pass any options supported by @panzoom/panzoom
     // See: https://github.com/timmywil/panzoom for available options
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r74tech/docusaurus-plugin-panzoom",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A plugin to enable the panzoom component on SVG and other elements",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/PanZoom.ts
+++ b/src/PanZoom.ts
@@ -5,7 +5,7 @@ import { PanZoomPluginOptions } from "./PanzoomPluginOptions";
 const config = require('@generated/docusaurus.config').default;
 const { themeConfig } = config;
 const { zoom }: { zoom: PanZoomPluginOptions } = themeConfig;
-const { selectors = ['div.mermaid[data-processed="true"]', 'div.docusaurus-mermaid-container', '.drawio'], wrap = true, timeout = 1000, ...panZoomConfig } = zoom;
+const { selectors = ['div.mermaid[data-processed="true"]', 'div.docusaurus-mermaid-container', '.drawio'], wrap = true, timeout = 1000, excludeClass = 'panzoom-exclude', ...panZoomConfig } = zoom;
 
 /**
  * Main work method to zoom the set of elements.  You can pass in global options to the pan zoom component
@@ -18,7 +18,7 @@ const zoomElements = (selectors: string[]) => {
     foundElements.push(...document.querySelectorAll(selector));
   });
   foundElements.forEach((element) => {
-    const instance = panzoom(element as HTMLElement, panZoomConfig);
+    const instance = panzoom(element as HTMLElement, { excludeClass, ...panZoomConfig });
     if (wrap) {
       const wrapper = document.createElement('div');
       wrapper.setAttribute('style', "overflow: hidden");

--- a/src/PanZoomPlugin.ts
+++ b/src/PanZoomPlugin.ts
@@ -28,6 +28,7 @@ const panZoomValidator = Joi.object({
     selectors: Joi.array<string>(),
     wrap: Joi.boolean(),
     timeout: Joi.number(),
+    excludeClass: Joi.string(),
   })
 })
 

--- a/src/PanzoomPluginOptions.ts
+++ b/src/PanzoomPluginOptions.ts
@@ -25,4 +25,12 @@ export type PanZoomPluginOptions = PanzoomOptions & {
    * The default is 1000
    */
   timeout?: number;
+  
+  /**
+   * Add this class to any element within the Panzoom element that you want to exclude from Panzoom handling.
+   * That element's children will also be excluded. e.g. links and buttons that should not propagate the click event.
+   * 
+   * default: 'panzoom-exclude'
+   */
+  excludeClass?: string;
 }


### PR DESCRIPTION
This commit implements support for the excludeClass option from the underlying
panzoom library. This allows users to exclude specific elements from panzoom
handling by adding a CSS class to them.

Changes include:
- Added excludeClass option to PanZoomPluginOptions with documentation
- Updated validation schema in PanZoomPlugin.ts
- Modified PanZoom.ts to extract and pass the excludeClass option
- Updated README.md with documentation for the new option
- Bumped version to 2.1.0

The default value for excludeClass is 'panzoom-exclude', matching the
underlying library's default.

Resolves: https://github.com/act-org/docusaurus-plugin-panzoom/issues/2 with users unable to exclude certain elements from panzoom