### PR TITLE
feat: add options to better control the zoom

### DIFF
--- a/docs/docs/01-intro.md
+++ b/docs/docs/01-intro.md
@@ -17,7 +17,10 @@ This plugin implements the excellent [@panzoom/panzoom](https://www.npmjs.com/pa
 - Works with [Mermaid](https://mermaid-js.github.io/mermaid/) generated diagrams
 - Customizable selectors to target specific elements
 - Option to wrap elements to contain them within their original container
-- Wheel zoom and double-click reset functionality
+- Option to use mouse wheel or pinch to zoom
+- Option to use shift + mouse wheel or pinch to zoom
+- Option to use double-click to reset the zoom
+- Option to restrict zooming out beyond the original size of the element
 - Toolbar for zooming in and out and resetting the view
 
 ## Note

--- a/docs/docs/02-user-interactions.md
+++ b/docs/docs/02-user-interactions.md
@@ -3,7 +3,7 @@
 For elements with pan and zoom functionality enabled, users can:
 
 - **Pan**: Click and drag the element to move the view area
-- **Zoom**: Use the mouse wheel to zoom in and out of the element
+- **Zoom**: Use the mouse wheel (and/or shift + mouse wheel) to zoom in and out of the element
 - **Reset**: Double-click the element to reset to the original view state
 
 If the toolbar is enabled, users can also use the toolbar buttons to zoom in, zoom out, and reset the view. See the

--- a/docs/docs/03-getting-started/02-configuration.md
+++ b/docs/docs/03-getting-started/02-configuration.md
@@ -41,6 +41,41 @@ module.exports = {
         opacity: 0,
       },
 
+      /**
+       * Whether to enable zooming with the mouse wheel.
+       * If true, the user can zoom in and out using the mouse wheel.
+       *
+       * default: true
+       */
+      enableWheelZoom: true,
+
+      /**
+       * Whether to enable zooming with the mouse wheel while holding the shift key.
+       * If true, the user can zoom in and out using the mouse wheel while holding the shift key.
+       *
+       * This option is independent of `enableWheelZoom`. Meaning, even if `enableWheelZoom` is false,
+       * and `enableWheelZoonWithShift` is true, the user can still zoom using shift + mouse whee.
+       * Also, `enableWheelZoom` and `enableWheelZoonWithShift` can be used together.
+       *
+       * default: false
+       */
+      enableWheelZoonWithShift: false,
+
+      /**
+       * Whether to enable double-click to reset zoom.
+       * If true, double-clicking on the panzoom element will reset the zoom level.
+       *
+       * default: true
+       */
+      enableDoubleClickResetZoom: true,
+
+      /**
+       * Whether to restrict zooming out beyond the original size of the element.
+       *
+       * default: false
+       */
+      restrictZoomOutBeyondOrigin: false,
+      
       // You can also pass any options supported by @panzoom/panzoom
       // See: https://github.com/timmywil/panzoom for available options
     },

--- a/docs/docs/03-getting-started/02-configuration.md
+++ b/docs/docs/03-getting-started/02-configuration.md
@@ -54,12 +54,12 @@ module.exports = {
        * If true, the user can zoom in and out using the mouse wheel while holding the shift key.
        *
        * This option is independent of `enableWheelZoom`. Meaning, even if `enableWheelZoom` is false,
-       * and `enableWheelZoonWithShift` is true, the user can still zoom using shift + mouse whee.
-       * Also, `enableWheelZoom` and `enableWheelZoonWithShift` can be used together.
+       * and `enableWheelZoomWithShift` is true, the user can still zoom using shift + mouse whee.
+       * Also, `enableWheelZoom` and `enableWheelZoomWithShift` can be used together.
        *
        * default: false
        */
-      enableWheelZoonWithShift: false,
+      enableWheelZoomWithShift: false,
 
       /**
        * Whether to enable double-click to reset zoom.

--- a/src/PanZoom.ts
+++ b/src/PanZoom.ts
@@ -15,11 +15,16 @@ const {
   timeout = 1000,
   excludeClass = 'panzoom-exclude',
   toolbar: { enabled = false, position = PanZoomPluginToolbarPosition.TopRight, opacity = 0 } = {},
+  enableWheelZoom = true,
+  enableWheelZoonWithShift = false,
+  enableDoubleClickResetZoom = true,
+  restrictZoomOutBeyondOrigin = false,
   ...panZoomConfig
 } = zoom;
 
 /**
  * Creates a toolbar with zoom controls for a panzoom instance
+ *
  * @param container The container element to append the toolbar to
  * @param instance The panzoom instance to control
  * @param position The position of the toolbar
@@ -52,10 +57,26 @@ const createToolbar = (container: HTMLElement, instance: PanzoomObject, position
   };
 
   // Create and append all buttons
+
   const buttons = [
-    createButton(SvgZoomIn, 'Zoom in', () => instance.zoomIn()),
-    createButton(SvgZoomOut, 'Zoom out', () => instance.zoomOut()),
-    createButton(SvgZoomReset, 'Reset zoom', () => instance.reset()),
+    // Zoom in
+    createButton(SvgZoomIn, 'Zoom in', () => {
+      instance.zoomIn();
+    }),
+    // Zoom out
+    createButton(SvgZoomOut, 'Zoom out', () => {
+      if (!restrictZoomOutBeyondOrigin) {
+        instance.zoomOut();
+        return;
+      }
+      if (instance.getScale() > 1) {
+        instance.zoomOut();
+      }
+    }),
+    // Reset zoom
+    createButton(SvgZoomReset, 'Reset zoom', () => {
+      instance.reset();
+    }),
   ];
 
   buttons.forEach((button) => toolbar.appendChild(button));
@@ -63,15 +84,61 @@ const createToolbar = (container: HTMLElement, instance: PanzoomObject, position
 };
 
 /**
+ * Attach event listeners to the element where panzoom is applied.
+ * The listeners to add are based on the configuration options provided.
+ *
+ * @param element The element to add event listeners to
+ * @param instance The panzoom instance to control
+ */
+const addEventListeners = (element: HTMLElement, instance: PanzoomObject) => {
+  const handleZoomWithWheel = (event: WheelEvent) => {
+    if (restrictZoomOutBeyondOrigin) {
+      // Allow zooming in or zooming out only to the original size
+      if (event.deltaY < 0 || (event.deltaY > 0 && instance.getScale() > 1)) {
+        instance.zoomWithWheel(event);
+      }
+    } else {
+      instance.zoomWithWheel(event);
+    }
+  };
+
+  // Handle the wheel zoom functionality if at least one of the options is enabled
+  if (enableWheelZoom || enableWheelZoonWithShift) {
+    element.addEventListener('wheel', (event) => {
+      // Handle zoom with shift key
+      if (enableWheelZoonWithShift && event.shiftKey) {
+        handleZoomWithWheel(event);
+        return;
+      }
+
+      // Handle regular zoom
+      if (enableWheelZoom && !event.shiftKey) {
+        handleZoomWithWheel(event);
+      }
+    });
+  }
+
+  // Handle double-click reset zoom
+  if (enableDoubleClickResetZoom) {
+    element.addEventListener('dblclick', () => {
+      instance.reset();
+    });
+  }
+};
+
+/**
  * Main work method to zoom the set of elements.  You can pass in global options to the pan zoom component
  * as well as control whether the items will be wrapped.
+ *
  * @param selectors
  */
 const zoomElements = (selectors: string[]) => {
   const foundElements: Element[] = [];
+
   selectors.forEach((selector) => {
     foundElements.push(...document.querySelectorAll(selector));
   });
+
   foundElements.forEach((element) => {
     const instance = panzoom(element as HTMLElement, { excludeClass, ...panZoomConfig });
     let container: HTMLElement;
@@ -81,23 +148,14 @@ const zoomElements = (selectors: string[]) => {
       wrapper.setAttribute('style', 'overflow: hidden; position: relative;');
       element.parentElement?.insertBefore(wrapper, element);
       wrapper.appendChild(element);
-      wrapper.addEventListener('wheel', (event) => {
-        instance.zoomWithWheel(event);
-      });
-      wrapper.addEventListener('dblclick', () => {
-        instance.reset();
-      });
       container = wrapper;
     } else {
-      (element as HTMLElement).style.position = 'relative';
-      (element as HTMLElement).addEventListener('wheel', (event) => {
-        instance.zoomWithWheel(event);
-      });
-      (element as HTMLElement).addEventListener('dblclick', () => {
-        instance.reset();
-      });
-      container = element as HTMLElement;
+      const htmlElement = element as HTMLElement;
+      htmlElement.style.position = 'relative';
+      container = htmlElement;
     }
+
+    addEventListeners(container, instance);
 
     // Add toolbar if enabled
     if (enabled) {

--- a/src/PanZoom.ts
+++ b/src/PanZoom.ts
@@ -16,7 +16,7 @@ const {
   excludeClass = 'panzoom-exclude',
   toolbar: { enabled = false, position = PanZoomPluginToolbarPosition.TopRight, opacity = 0 } = {},
   enableWheelZoom = true,
-  enableWheelZoonWithShift = false,
+  enableWheelZoomWithShift = false,
   enableDoubleClickResetZoom = true,
   restrictZoomOutBeyondOrigin = false,
   ...panZoomConfig
@@ -103,10 +103,10 @@ const addEventListeners = (element: HTMLElement, instance: PanzoomObject) => {
   };
 
   // Handle the wheel zoom functionality if at least one of the options is enabled
-  if (enableWheelZoom || enableWheelZoonWithShift) {
+  if (enableWheelZoom || enableWheelZoomWithShift) {
     element.addEventListener('wheel', (event) => {
       // Handle zoom with shift key
-      if (enableWheelZoonWithShift && event.shiftKey) {
+      if (enableWheelZoomWithShift && event.shiftKey) {
         handleZoomWithWheel(event);
         return;
       }

--- a/src/PanzoomPluginOptions.ts
+++ b/src/PanzoomPluginOptions.ts
@@ -67,4 +67,39 @@ export type PanZoomPluginOptions = PanzoomOptions & {
      */
     opacity?: number;
   };
+
+  /**
+   * Whether to enable zooming with the mouse wheel.
+   * If true, the user can zoom in and out using the mouse wheel.
+   *
+   * default: true
+   */
+  enableWheelZoom?: boolean;
+
+  /**
+   * Whether to enable zooming with the mouse wheel while holding the shift key.
+   * If true, the user can zoom in and out using the mouse wheel while holding the shift key.
+   *
+   * This option is independent of `enableWheelZoom`. Meaning, even if `enableWheelZoom` is false,
+   * and `enableWheelZoonWithShift` is true, the user can still zoom using shift + mouse whee.
+   * Also, `enableWheelZoom` and `enableWheelZoonWithShift` can be used together.
+   *
+   * default: false
+   */
+  enableWheelZoonWithShift?: boolean;
+
+  /**
+   * Whether to enable double-click to reset zoom.
+   * If true, double-clicking on the panzoom element will reset the zoom level.
+   *
+   * default: true
+   */
+  enableDoubleClickResetZoom?: boolean;
+
+  /**
+   * Whether to restrict zooming out beyond the original size of the element.
+   *
+   * default: false
+   */
+  restrictZoomOutBeyondOrigin?: boolean;
 };

--- a/src/PanzoomPluginOptions.ts
+++ b/src/PanzoomPluginOptions.ts
@@ -81,12 +81,12 @@ export type PanZoomPluginOptions = PanzoomOptions & {
    * If true, the user can zoom in and out using the mouse wheel while holding the shift key.
    *
    * This option is independent of `enableWheelZoom`. Meaning, even if `enableWheelZoom` is false,
-   * and `enableWheelZoonWithShift` is true, the user can still zoom using shift + mouse whee.
-   * Also, `enableWheelZoom` and `enableWheelZoonWithShift` can be used together.
+   * and `enableWheelZoomWithShift` is true, the user can still zoom using shift + mouse whee.
+   * Also, `enableWheelZoom` and `enableWheelZoomWithShift` can be used together.
    *
    * default: false
    */
-  enableWheelZoonWithShift?: boolean;
+  enableWheelZoomWithShift?: boolean;
 
   /**
    * Whether to enable double-click to reset zoom.


### PR DESCRIPTION
# Overview

This pull request introduces new configuration options to improve the zoom functionality. These changes allow developers to customize how event listeners are registered, offering greater flexibility and control over the plugin’s behavior.

_N.B: just using @panzoom/panzoom options (instead of this PR) is not possible because of hardcoded event listeners in this plugin._

# Motivation

Currently, the plugin adds hardcoded event listeners to handle zoom behavior. While this works in many cases, it lacks configurability. This becomes problematic when the default behavior doesn’t suit all input methods.

In particular, the current implementation of the wheel event causes issues when using a touchpad.

Scrolling with a mouse works as expected:
![computer-mouse-hq](https://github.com/user-attachments/assets/4936ebcd-735b-401b-a22d-98465c525a36)

However, with a touchpad, the scroll gestures often conflict with the zoom handling, making navigation difficult:
![touchpad-scroll](https://github.com/user-attachments/assets/e494984e-53a5-416f-8a7a-d6473ac4729b)

# Alternative solution considered

One idea was to differentiate between a touchpad and a mouse wheel by checking the event.deltaMode and event.deltaY values. Touchpad scrolls typically have smaller deltaY values and use deltaMode set to 0 (DOM_DELTA_PIXEL), while mouse wheels often have larger deltaY values and may use deltaMode set to 1 (DOM_DELTA_LINE).

Example:

```ts
// Do not use this code! (see below)!

wrapper.addEventListener('wheel', (event) => {
  // Check if the event is from a mouse wheel
  if (event.deltaMode === 1 || Math.abs(event.deltaY) > 10) {
    instance.zoomWithWheel(event);
  } else {
    // Ignoring touchpad scroll...
  }
});
```

Unfortunately, this method isn’t reliable across all devices and user behaviors. Factors like scroll speed, gesture style, and hardware differences make it difficult to consistently distinguish between input types.

# Proposed solution

Rather than relying on unreliable heuristics, this pull request adds options to give developers fine-grained control over zoom behavior and event listener management. This enables projects with specific needs — such as touchpad support — to opt out of default behaviors, or opt in to other handling if desired.

## enableWheelZoom

This option enables or disables zooming with the mouse wheel or touchpad (i.e. using the wheel event). By default, it is set to `true` to preserve the current behavior.

## enableWheelZoonWithShift

Enables zooming with the mouse wheel only while holding the Shift key.

This option allows users to zoom in and out by holding Shift and scrolling with the mouse wheel (or pinching the touchpad), regardless of whether`enableWheelZoom` is enabled.
- If`enableWheelZoom` is `false` but`enableWheelZoomWithShift` is `true`, zooming is still possible using Shift + wheel (or touchpad).
- Both options can be enabled at the same time, allowing for both standard wheel zoom and Shift-based zoom.

This provides flexibility for developers who want to avoid accidental zooming during regular scrolling, while still offering an intentional zoom mechanism.

It's inspired by the ["Panning and focal-point zooming (shift + mousewheel)"](https://timmywil.com/panzoom/demo/#Panning%20and%20focal-point%20zooming%20(shift%20%2B%20mousewheel)) demo of the`@panzoom/panzoom` library.

By default, it is set to `false`.

## enableDoubleClickResetZoom

Enables resetting the zoom level via double-click.

If set to true, double-clicking anywhere on the panzoom element will reset the zoom to its initial state.

This offers a simple and intuitive way for users to quickly return to the initial zoom level.

By default, it is set to `true` to preserve the current behavior.

## restrictZoomOutBeyondOrigin

Prevents zooming out beyond the original size of the element.

When enabled, users will not be able to zoom out below the element’s initial scale. This is useful for keeping content readable and anchored within expected boundaries.

By default, it is set to `false`.

When `restrictZoomOutBeyondOrigin` is set to `false`:
![restrictZoomOutBeyondOrigin-false](https://github.com/user-attachments/assets/1803ef36-16a5-4172-b9ff-d75bb8f14267)

When `restrictZoomOutBeyondOrigin` is set to `true`:
![restrictZoomOutBeyondOrigin-true](https://github.com/user-attachments/assets/d9e88bf3-ef39-4c8b-af30-2a2aa4cf9f6f)

# Testing

Verified the zoom functionality with various configurations, and with mouse and touchpad.

# Documentation

Enhanced the docs section to reflect the new configuration options in the following pages:
- User Interactions
- Configuration

---

@r74tech, let me know if further adjustments are needed!

Best,